### PR TITLE
[feature]实现索引管理器以实现简单的手动索引更新，修复两个bug，默认使用mobileclip，结果增加到800个

### DIFF
--- a/app/src/main/java/me/grey/picquery/common/AppModules.kt
+++ b/app/src/main/java/me/grey/picquery/common/AppModules.kt
@@ -66,6 +66,7 @@ private val domainModules = module {
         AlbumManager(
             albumRepository = get(),
             photoRepository = get(),
+            embeddingRepository = get(),
             imageSearcher = get(),
         )
     }
@@ -74,7 +75,7 @@ private val domainModules = module {
 }
 
 // need inject encoder here
-val AppModules = listOf(viewModelModules, dataModules, modulesCLIP, domainModules)
+//val AppModules = listOf(viewModelModules, dataModules, modulesCLIP, domainModules)
 //val AppModules = listOf(viewModelModules, dataModules, modulesMobileCLIP2, domainModules)
-//val AppModules = listOf(viewModelModules, dataModules, modulesMobileCLIP, domainModules)
+val AppModules = listOf(viewModelModules, dataModules, modulesMobileCLIP, domainModules)
 

--- a/app/src/main/java/me/grey/picquery/common/Routes.kt
+++ b/app/src/main/java/me/grey/picquery/common/Routes.kt
@@ -4,5 +4,6 @@ enum class Routes {
     Home,
     Search,
     Display,
-    Setting
+    Setting,
+    IndexMgr,
 }

--- a/app/src/main/java/me/grey/picquery/data/dao/EmbeddingDao.kt
+++ b/app/src/main/java/me/grey/picquery/data/dao/EmbeddingDao.kt
@@ -28,6 +28,12 @@ interface EmbeddingDao {
     )
     fun getByAlbumIdList(albumIds: List<Long>): List<Embedding>
 
+    @Query(
+        "DELETE FROM $tableName WHERE album_id=(:albumId)"
+    )
+    fun removeByAlbumId(albumId: Long): Unit
+
+
 //    @Insert
 //    fun insertAll(embeddings: List<Embedding>)
 

--- a/app/src/main/java/me/grey/picquery/data/data_source/AlbumRepository.kt
+++ b/app/src/main/java/me/grey/picquery/data/data_source/AlbumRepository.kt
@@ -96,4 +96,8 @@ class AlbumRepository(
     fun addAllSearchableAlbum(album: List<Album>) {
         return database.albumDao().upsertAll(album)
     }
+
+    fun removeSearchableAlbum(singleAlbum: Album) {
+        return database.albumDao().delete(singleAlbum)
+    }
 }

--- a/app/src/main/java/me/grey/picquery/data/data_source/EmbeddingRepository.kt
+++ b/app/src/main/java/me/grey/picquery/data/data_source/EmbeddingRepository.kt
@@ -59,4 +59,8 @@ class EmbeddingRepository(
     fun updateAll(list: List<Embedding>) {
         return database.embeddingDao().upsertAll(list)
     }
+
+    fun removeByAlbum(album: Album){
+        return database.embeddingDao().removeByAlbumId(album.id)
+    }
 }

--- a/app/src/main/java/me/grey/picquery/domain/ImageSearcher.kt
+++ b/app/src/main/java/me/grey/picquery/domain/ImageSearcher.kt
@@ -61,7 +61,7 @@ class ImageSearcher(
     companion object {
         private const val TAG = "ImageSearcher"
         private const val DEFAULT_MATCH_THRESHOLD = 0.01
-        private const val TOP_K = 30
+        private const val TOP_K = 800
     }
 
     val searchRange = mutableStateListOf<Album>()

--- a/app/src/main/java/me/grey/picquery/ui/AppNavHost.kt
+++ b/app/src/main/java/me/grey/picquery/ui/AppNavHost.kt
@@ -13,6 +13,7 @@ import me.grey.picquery.common.Animation.navigateUpAnimation
 import me.grey.picquery.common.Routes
 import me.grey.picquery.ui.display.DisplayScreen
 import me.grey.picquery.ui.home.HomeScreen
+import me.grey.picquery.ui.indexmgr.IndexMgrScreen
 import me.grey.picquery.ui.search.SearchScreen
 import me.grey.picquery.ui.setting.SettingScreen
 
@@ -64,6 +65,14 @@ fun AppNavHost(
         }
         composable(Routes.Setting.name) {
             SettingScreen(
+                onNavigateBack = { navController.popBackStack() },
+                navigateToIndexMgr = {
+                    navController.navigate(Routes.IndexMgr.name)
+                }
+            )
+        }
+        composable(Routes.IndexMgr.name) {
+            IndexMgrScreen(
                 onNavigateBack = { navController.popBackStack() },
             )
         }

--- a/app/src/main/java/me/grey/picquery/ui/display/DisplayViewModel.kt
+++ b/app/src/main/java/me/grey/picquery/ui/display/DisplayViewModel.kt
@@ -22,7 +22,11 @@ class DisplayViewModel(
         currentIndex.intValue = initialPage
         viewModelScope.launch {
             val ids = imageSearcher.searchResultIds
-            photoList.addAll(photoRepository.getPhotoListByIds(ids))
+            val resultIdSimpleList = ids.toList()
+            val photos = photoRepository.getPhotoListByIds(resultIdSimpleList)
+            val photoMap = photos.associateBy { it.id }
+            val photoListOrdered =  resultIdSimpleList.mapNotNull { id -> photoMap[id] }
+            photoList.addAll(photoListOrdered)
         }
     }
 }

--- a/app/src/main/java/me/grey/picquery/ui/indexmgr/IndexMgr.kt
+++ b/app/src/main/java/me/grey/picquery/ui/indexmgr/IndexMgr.kt
@@ -1,0 +1,137 @@
+package me.grey.picquery.ui.indexmgr
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.NoPhotography
+import androidx.compose.material.icons.filled.PhotoAlbum
+import androidx.compose.material.icons.filled.SyncProblem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import me.grey.picquery.data.model.Album
+import me.grey.picquery.domain.AlbumManager
+import me.grey.picquery.ui.common.BackButton
+import org.koin.compose.koinInject
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+val FlagAlbumStatusNormal = 0
+val FlagAlbumStatusInvalid = 1
+val FlagAlbumStatusUpdateNeeded = 2
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun IndexMgrScreen(
+    onNavigateBack: () -> Unit,
+    albumManager: AlbumManager = koinInject(),
+) {
+    val indexedAlbum = albumManager.searchableAlbumListRaw
+    val allAlbum = albumManager.albumList
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("索引管理器(点击删除对应索引)") },
+                navigationIcon = { BackButton { onNavigateBack() } },
+            )
+        },
+        modifier = Modifier.padding(horizontal = 5.dp)
+    ) {
+        LazyColumn(modifier = Modifier.padding(it)) {
+            repeat(indexedAlbum.size) { index ->
+                val album = indexedAlbum[index]
+                if (allAlbum.any { a -> a.id == album.id }) {
+                    val albumNow = allAlbum.find{ item -> item.id == album.id }
+                    if (albumNow!!.count != album.count || albumNow!!.timestamp != album.timestamp) {
+                        item { AlbumItem(indexedAlbum, album, albumManager, FlagAlbumStatusUpdateNeeded) }
+                    } else {
+                        item { AlbumItem(indexedAlbum, album, albumManager, FlagAlbumStatusNormal) }
+                    }
+                } else {
+                    item{AlbumItem(indexedAlbum, album, albumManager, FlagAlbumStatusInvalid)}
+                }
+
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlbumItem(indexedAlbum: SnapshotStateList<Album>, album: Album, albumManager: AlbumManager, albumStatusEnum: Int) {
+    var isLoading by remember { mutableStateOf(false) }
+    var isDone by remember { mutableStateOf(false) }
+    var dateFmt = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.CHINESE)
+    var dateStr = dateFmt.format(Date(album.timestamp as Long * 1000))
+    var descString = "图片数：${album.count} 日期：${dateStr}"
+    if (albumStatusEnum == FlagAlbumStatusInvalid){
+        descString += "\n  此相册似乎无效"
+    } else if (albumStatusEnum == FlagAlbumStatusUpdateNeeded) {
+        descString += "\n  此相册似乎需要更新"
+    }
+    ListItem(
+        leadingContent = {
+            if (albumStatusEnum == FlagAlbumStatusInvalid){
+                Icon(
+                    imageVector = Icons.Filled.NoPhotography,
+                    contentDescription = "This album seems to be invalid, click to delete the index for this album"
+                )
+            } else if (albumStatusEnum == FlagAlbumStatusUpdateNeeded) {
+                Icon(
+                    imageVector = Icons.Filled.SyncProblem,
+                    contentDescription = "This album seems need update, click to delete the index for this album"
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Filled.PhotoAlbum,
+                    contentDescription = "Click to delete the index for this album"
+                )
+            }
+        },
+        headlineContent = { Text(text = album.label) },
+        supportingContent = {
+            if (isLoading) {
+                Text(text = "请稍后")
+            }
+            if (isDone) {
+                Text(text = "此项目的索引已删除")
+            } else {
+                Text(text = descString)
+            }
+        },
+        modifier = Modifier.clickable (enabled = !isLoading && !isDone) {
+            if (indexedAlbum.any { i -> i.id == album.id }) {
+                isLoading = true
+                GlobalScope.launch(Dispatchers.Main) {
+                    removeIndexByAlbum(indexedAlbum, album, albumManager)
+                }.invokeOnCompletion {
+                    isDone = true
+                }
+            }
+        }
+    )
+}
+
+private suspend fun removeIndexByAlbum (indexedAlbum: SnapshotStateList<Album>, album: Album, albumManager: AlbumManager){
+    withContext(Dispatchers.IO) {
+        albumManager.removeSingleAlbumIndex(album)
+    }
+}

--- a/app/src/main/java/me/grey/picquery/ui/indexmgr/IndexMgr.kt
+++ b/app/src/main/java/me/grey/picquery/ui/indexmgr/IndexMgr.kt
@@ -108,11 +108,10 @@ private fun AlbumItem(indexedAlbum: SnapshotStateList<Album>, album: Album, albu
         },
         headlineContent = { Text(text = album.label) },
         supportingContent = {
-            if (isLoading) {
-                Text(text = "请稍后")
-            }
             if (isDone) {
                 Text(text = "此项目的索引已删除")
+            } else if (isLoading) {
+                Text(text = "请稍后")
             } else {
                 Text(text = descString)
             }

--- a/app/src/main/java/me/grey/picquery/ui/indexmgr/IndexMgrViewModel.kt
+++ b/app/src/main/java/me/grey/picquery/ui/indexmgr/IndexMgrViewModel.kt
@@ -1,0 +1,5 @@
+package me.grey.picquery.ui.indexmgr
+
+import androidx.lifecycle.ViewModel
+
+class SettingViewModel() : ViewModel() {}

--- a/app/src/main/java/me/grey/picquery/ui/search/SearchFilterBottomSheet.kt
+++ b/app/src/main/java/me/grey/picquery/ui/search/SearchFilterBottomSheet.kt
@@ -2,11 +2,15 @@ package me.grey.picquery.ui.search
 
 import AppBottomSheetState
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.outlined.AddCircleOutline
@@ -106,7 +110,10 @@ fun SearchFilterBottomSheet(
         if (candidates.isEmpty()) {
             EmptyAlbumTips(onClose = { closeFilter() })
         } else {
-            Box(modifier = Modifier.padding(bottom = 55.dp)) {
+            Box(modifier = Modifier
+                .padding(bottom = 55.dp)
+                .draggable(state = rememberDraggableState(onDelta={}), orientation = Orientation.Horizontal)
+            ){
                 SearchAbleAlbums(
                     enabled = !searchAll.value,
                     candidates = candidates,
@@ -133,49 +140,55 @@ private fun SearchAbleAlbums(
 ) {
 //    val searchRange = remember { searchViewModel.searchRange }
 //    val all = remember { albumManager.searchableAlbumList }
-    FlowRow(
-        Modifier.padding(horizontal = 12.dp)
+    LazyColumn(
+        Modifier
+            .padding(horizontal = 12.dp)
+            .draggable(state = rememberDraggableState(
+                onDelta={}
+            ), orientation = Orientation.Horizontal)
     ) {
         repeat(candidates.size) { index ->
-            val album = candidates[index]
-            val selected = remember { mutableStateOf(selectedList.contains(album)) }
+            item{
+                val album = candidates[index]
+                val selected = remember { mutableStateOf(selectedList.contains(album)) }
 
-            val colors = FilterChipDefaults.elevatedFilterChipColors(
-                iconColor = MaterialTheme.colorScheme.primary,
-                selectedContainerColor = MaterialTheme.colorScheme.primary,
-                selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
-                selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimary,
-            )
+                val colors = FilterChipDefaults.elevatedFilterChipColors(
+                    iconColor = MaterialTheme.colorScheme.primary,
+                    selectedContainerColor = MaterialTheme.colorScheme.primary,
+                    selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                    selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimary,
+                )
 
-            ElevatedFilterChip(
-                enabled = enabled,
-                modifier = Modifier.padding(horizontal = 6.dp),
-                colors = colors,
-                leadingIcon = {
-                    Icon(
-                        modifier = Modifier.size(18.dp),
-                        imageVector = if (selected.value) {
-                            Icons.Filled.CheckCircle
-                        } else {
-                            Icons.Outlined.AddCircleOutline
-                        },
-                        contentDescription = "",
-                    )
-                },
-                selected = selected.value,
-                onClick = {
-                    if (enabled) {
-                        if (!selected.value) {
-                            onAdd(album)
-                            selected.value = true
-                        } else {
-                            onRemove(album)
-                            selected.value = false
+                ElevatedFilterChip(
+                    enabled = enabled,
+                    modifier = Modifier.padding(horizontal = 6.dp),
+                    colors = colors,
+                    leadingIcon = {
+                        Icon(
+                            modifier = Modifier.size(18.dp),
+                            imageVector = if (selected.value) {
+                                Icons.Filled.CheckCircle
+                            } else {
+                                Icons.Outlined.AddCircleOutline
+                            },
+                            contentDescription = "",
+                        )
+                    },
+                    selected = selected.value,
+                    onClick = {
+                        if (enabled) {
+                            if (!selected.value) {
+                                onAdd(album)
+                                selected.value = true
+                            } else {
+                                onRemove(album)
+                                selected.value = false
+                            }
                         }
-                    }
-                },
-                label = { Text(text = "${album.label} (${album.count})") }
-            )
+                    },
+                    label = { Text(text = "${album.label} (${album.count})") }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/me/grey/picquery/ui/setting/SettingScreen.kt
+++ b/app/src/main/java/me/grey/picquery/ui/setting/SettingScreen.kt
@@ -14,7 +14,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.Dataset
+import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.PermDeviceInformation
+import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -35,6 +38,7 @@ import androidx.core.content.ContextCompat.startActivity
 import me.grey.picquery.R
 import me.grey.picquery.common.Constants.PRIVACY_URL
 import me.grey.picquery.common.Constants.SOURCE_REPO_URL
+import me.grey.picquery.common.Routes
 import me.grey.picquery.ui.common.BackButton
 import org.koin.androidx.compose.koinViewModel
 
@@ -43,6 +47,7 @@ import org.koin.androidx.compose.koinViewModel
 @Composable
 fun SettingScreen(
     onNavigateBack: () -> Unit,
+    navigateToIndexMgr: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -59,6 +64,7 @@ fun SettingScreen(
             item { InformationRow() }
             item { Box(modifier = Modifier.height(15.dp)) }
             item { UploadLogSettingItem() }
+            item { AlbumIndexManagerUIItem(navigateToIndexMgr) }
         }
     }
 }
@@ -84,6 +90,21 @@ private fun UploadLogSettingItem(settingViewModel: SettingViewModel = koinViewMo
             )
         },
         modifier = Modifier.clickable { settingViewModel.setEnableUploadLog(!enable.value) }
+    )
+}
+
+@Composable
+private fun AlbumIndexManagerUIItem(navigateToIndexMgr: () -> Unit) {
+    ListItem(
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Filled.Dataset,
+                contentDescription = "Click to Manage Album Indexes"
+            )
+        },
+        headlineContent = { Text(text = stringResource(R.string.album_index_manager_ui_title)) },
+        supportingContent = { Text(text = stringResource(R.string.album_index_manager_ui_desc)) },
+        modifier = Modifier.clickable { navigateToIndexMgr() }
     )
 }
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -54,5 +54,12 @@
     <string name="external_storage">[外部存储]</string>
     <string name="view_privacy_policy">查看隐私政策</string>
     <string name="open_with_external_app">使用外部应用打开</string>
+    <string name="album_index_manager_ui_title">相册索引管理器</string>
+    <string name="album_index_manager_ui_desc">打开一个对话框来查看和删除已经索引的相册信息</string>
+    <string name="album_indexmgr_ui_seems_invalid">此相册似乎无效.</string>
+    <string name="album_indexmgr_ui_album">相册:</string>
+    <string name="album_indexmgr_ui_album_photo_count">图片数:</string>
+    <string name="album_indexmgr_ui_album_timestamp">时间戳:</string>
+    <string name="album_indexmgr_ui_long_click_to_delete">点击以删除对应相册的索引信息</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,4 +53,11 @@
     <string name="external_storage">[External Storage]</string>
     <string name="view_privacy_policy">View privacy policy</string>
     <string name="open_with_external_app">Open with External Apps</string>
+    <string name="album_index_manager_ui_title">Album Index Manager</string>
+    <string name="album_index_manager_ui_desc">Open an Dialog to Review and Delete Album Index Data</string>
+    <string name="album_indexmgr_ui_seems_invalid">This album seems invalid.</string>
+    <string name="album_indexmgr_ui_album">Album:</string>
+    <string name="album_indexmgr_ui_album_photo_count">Photo Count:</string>
+    <string name="album_indexmgr_ui_album_timestamp">Timestamp:</string>
+    <string name="album_indexmgr_ui_long_click_to_delete">Click to delete the index for the corresponding album</string>
 </resources>


### PR DESCRIPTION
1.实现了索引管理器，可以对索引进行查询和删除，这样的话就可以原始的手动方式实现
1.1 删除索引
1.2 显示索引状态正常，索引需要更新（索引的图片数量或者时间戳和最新数据不一致），索引无效（相册已被删除）
1.3 更新索引（先删除再添加）
2. 修复两个bug
2.1 修复了结果页面缩略图和大图顺序不一致的bug
2.2 修复了选择要搜索的相册列表时列表超出屏幕时无法滚动选择的bug
3.默认使用mobileclip，我感觉效果稍好一点
4.默认返回800个结果，由于现在可以按相关性排序，多返回一些也可以
我不是正经的安卓工程师，所以代码质量估计比较差，请理解。
提交完这部分代码后，本应用就基本实现了我个人希望实现的所有功能。
不知为何，在双引号定义字符串中引用R本地化库不工作，所以一部分新增字符串硬编码了，请作者修复